### PR TITLE
Respect prefers-reduced-motion setting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,8 @@ You can change the emoji in `emojiCursor`'s emoji with the `emoji` option (a lis
 ```js
 new cursoreffects.emojiCursor({emoji: ["🔥", "🐬", "🦆"]});
 ```
+## Accessibility
+The cursor won't display if the user's system accessibility settings have [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) enabled.
 
 ### trailingCursor
 

--- a/src/bubbleCursor.js
+++ b/src/bubbleCursor.js
@@ -10,8 +10,26 @@ export function bubbleCursor(options) {
 
   let canvImages = []
 
-  function init(wrapperEl) {
-    canvas = document.createElement("canvas")
+  const prefersReducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)'
+  )
+
+  // Re-initialise or destroy the cursor when the prefers-reduced-motion setting changes
+  prefersReducedMotion.onchange = () => {
+    if (prefersReducedMotion.matches) {
+      destroy()
+    } else {
+      init()
+    }
+  }
+
+  function init() {
+    // Don't show the cursor trail if the user has prefers-reduced-motion enabled
+    if (prefersReducedMotion.matches) {
+      return false
+    }
+    canvas = document.createElement('canvas')
+    canvas.id = 'cursor-trail'
     context = canvas.getContext("2d")
 
     canvas.style.top = "0px"
@@ -105,6 +123,13 @@ export function bubbleCursor(options) {
     requestAnimationFrame(loop)
   }
 
+  function destroy() {
+    const cursor = document.getElementById('cursor-trail')
+    if (cursor) {
+      cursor.remove()
+    }
+  }
+  
   function Particle(x, y, canvasItem) {
     const lifeSpan = Math.floor(Math.random() * 60 + 60)
     this.initialLifeSpan = lifeSpan //

--- a/src/clockCursor.js
+++ b/src/clockCursor.js
@@ -109,8 +109,26 @@ export function clockCursor(options) {
         secondHand.length
     ) + 1;
 
-  function init(wrapperEl) {
-    canvas = document.createElement("canvas");
+  const prefersReducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)'
+  );
+
+  // Re-initialise or destroy the cursor when the prefers-reduced-motion setting changes
+  prefersReducedMotion.onchange = () => {
+    if (prefersReducedMotion.matches) {
+      destroy();
+    } else {
+      init();
+    }
+  };
+
+  function init() {
+    // Don't show the cursor trail if the user has prefers-reduced-motion enabled
+    if (prefersReducedMotion.matches) {
+      return false;
+    }
+    canvas = document.createElement('canvas');
+    canvas.id = 'cursor-trail';  
     context = canvas.getContext("2d");
 
     canvas.style.top = "0px";
@@ -320,6 +338,13 @@ export function clockCursor(options) {
     updateParticles();
 
     requestAnimationFrame(loop);
+  }
+
+  function destroy() {
+    const cursor = document.getElementById('cursor-trail');
+    if (cursor) {
+      cursor.remove();
+    }
   }
 
   init();

--- a/src/emojiCursor.js
+++ b/src/emojiCursor.js
@@ -12,8 +12,26 @@ export function emojiCursor(options) {
   const canvImages = []
   let canvas, context
 
+  const prefersReducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)'
+  )
+
+  // Re-initialise or destroy the cursor when the prefers-reduced-motion setting changes
+  prefersReducedMotion.onchange = () => {
+    if (prefersReducedMotion.matches) {
+      destroy()
+    } else {
+      init()
+    }
+  }
+
   function init() {
-    canvas = document.createElement("canvas")
+    // Don't show the cursor trail if the user has prefers-reduced-motion enabled
+    if (prefersReducedMotion.matches) {
+      return false
+    }
+    canvas = document.createElement('canvas')
+    canvas.id = 'cursor-trail'
     context = canvas.getContext("2d")
 
     canvas.style.top = "0px"
@@ -151,6 +169,13 @@ export function emojiCursor(options) {
   function loop() {
     updateParticles()
     requestAnimationFrame(loop)
+  }  
+  
+  function destroy() {
+    const cursor = document.getElementById('cursor-trail')
+    if (cursor) {
+      cursor.remove()
+    }
   }
 
   /**

--- a/src/fairyDustCursor.js
+++ b/src/fairyDustCursor.js
@@ -17,8 +17,26 @@ export function fairyDustCursor(options) {
 
   const char = "*";
 
+  const prefersReducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)'
+  );
+
+  // Re-initialise or destroy the cursor when the prefers-reduced-motion setting changes
+  prefersReducedMotion.onchange = () => {
+    if (prefersReducedMotion.matches) {
+      destroy();
+    } else {
+      init();
+    }
+  }
+
   function init() {
-    canvas = document.createElement("canvas");
+    // Don't show the cursor trail if the user has prefers-reduced-motion enabled
+    if (prefersReducedMotion.matches) {
+      return false;
+    }
+    canvas = document.createElement('canvas');
+    canvas.id = 'cursor-trail';
     context = canvas.getContext("2d");
     canvas.style.top = "0px";
     canvas.style.left = "0px";
@@ -153,6 +171,15 @@ export function fairyDustCursor(options) {
     updateParticles();
     requestAnimationFrame(loop);
   }
+
+
+  function destroy() {
+    const cursor = document.getElementById('cursor-trail')
+    if (cursor) {
+      cursor.remove()
+    }
+  }
+
 
   function Particle(x, y, canvasItem) {
     const lifeSpan = Math.floor(Math.random() * 30 + 60);

--- a/src/followingDotCursor.js
+++ b/src/followingDotCursor.js
@@ -9,8 +9,26 @@ export function followingDotCursor(options) {
   let canvas, context;
   let color = options?.color || "#323232a6";
 
+  const prefersReducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)'
+  );
+
+  // Re-initialise or destroy the cursor when the prefers-reduced-motion setting changes
+  prefersReducedMotion.onchange = () => {
+    if (prefersReducedMotion.matches) {
+      destroy();
+    } else {
+      init();
+    }
+  };
+
   function init() {
-    canvas = document.createElement("canvas");
+    // Don't show the cursor trail if the user has prefers-reduced-motion enabled
+    if (prefersReducedMotion.matches) {
+      return false;
+    }
+    canvas = document.createElement('canvas');
+    canvas.id = 'cursor-trail';
     context = canvas.getContext("2d");
     canvas.style.top = "0px";
     canvas.style.left = "0px";
@@ -71,6 +89,13 @@ export function followingDotCursor(options) {
   function loop() {
     updateDot();
     requestAnimationFrame(loop);
+  }
+
+  function destroy() {
+    const cursor = document.getElementById('cursor-trail');
+    if (cursor) {
+      cursor.remove();
+    }
   }
 
   function Dot(x, y, width, lag) {

--- a/src/ghostCursor.js
+++ b/src/ghostCursor.js
@@ -12,8 +12,26 @@ export function ghostCursor(options) {
   baseImage.src =
     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAATCAYAAACk9eypAAAAAXNSR0IArs4c6QAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAhGVYSWZNTQAqAAAACAAFARIAAwAAAAEAAQAAARoABQAAAAEAAABKARsABQAAAAEAAABSASgAAwAAAAEAAgAAh2kABAAAAAEAAABaAAAAAAAAAEgAAAABAAAASAAAAAEAA6ABAAMAAAABAAEAAKACAAQAAAABAAAADKADAAQAAAABAAAAEwAAAAAChpcNAAAACXBIWXMAAAsTAAALEwEAmpwYAAABWWlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50YXRpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgpMwidZAAABqElEQVQoFY3SPUvDQBgH8BREpRHExYiDgmLFl6WC+AYmWeyLg4i7buJX8DMpOujgyxGvUYeCgzhUQUSKKLUS0+ZyptXh8Z5Ti621ekPyJHl+uftfomhaf9Ei5JyxXKfynyEA6EYcLHpwyflT958GAQ7DTABNHd8EbtDbEH2BD5QEQmi2mM8P/Iq+A0SzszEg+3sPjDnDdVEtQKQbMUidHD3xVzf6A9UDEmEm+8h9KTqTVUjT+vB53aHrCbAPiceYq1dQI1Aqv4EhMll0jzv+Y0yiRgCnLRSYyDQHVoqUXe4uKL9l+L7GXC4vkMhE6eW/AOJs9k583ORDUyXMZ8F5SVHVVnllmPNKSFagAJ5DofaqGXw/gHBYg51dIldkmknY3tguv3jOtHR4+MqAzaraJXbEhqHhcQlwGSOi5pytVQHZLN5s0WNe8HPrLYlFsO20RPHkImxsbmHdLJFI76th7Z4SeuF53hTeFLvhRCJRCTKZKxgdnRDbW+iozFJbBMw14/ElwGYc0egMBMFzT21f5Rog33Z7dX02GBm7WV5ZfT5Nn5bE3zuCDe9UxdTpNvK+5AAAAABJRU5ErkJggg==";
 
+  const prefersReducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)'
+  )
+
+  // Re-initialise or destroy the cursor when the prefers-reduced-motion setting changes
+  prefersReducedMotion.onchange = () => {
+    if (prefersReducedMotion.matches) {
+      destroy();
+    } else {
+      init();
+    }
+  }
+
   function init() {
-    canvas = document.createElement("canvas");
+    // Don't show the cursor trail if the user has prefers-reduced-motion enabled
+    if (prefersReducedMotion.matches) {
+      return false
+    }
+    canvas = document.createElement('canvas');
+    canvas.id = 'cursor-trail';
     context = canvas.getContext("2d");
     canvas.style.top = "0px";
     canvas.style.left = "0px";
@@ -102,6 +120,13 @@ export function ghostCursor(options) {
     requestAnimationFrame(loop);
   }
 
+  function destroy() {
+    const cursor = document.getElementById('cursor-trail');
+    if (cursor) {
+      cursor.remove();
+    }
+  }
+  
   /**
    * Particles
    */

--- a/src/rainbowCursor.js
+++ b/src/rainbowCursor.js
@@ -21,8 +21,26 @@ export function rainbowCursor(options) {
 
   let cursorsInitted = false;
 
+  const prefersReducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)'
+  );
+
+  // Re-initialise or destroy the cursor when the prefers-reduced-motion setting changes
+  prefersReducedMotion.onchange = () => {
+    if (prefersReducedMotion.matches) {
+      destroy();
+    } else {
+      init();
+    }
+  };
+
   function init() {
-    canvas = document.createElement("canvas");
+    // Don't show the cursor trail if the user has prefers-reduced-motion enabled
+    if (prefersReducedMotion.matches) {
+      return false;
+    }
+    canvas = document.createElement('canvas');
+    canvas.id = 'cursor-trail';
     context = canvas.getContext("2d");
     canvas.style.top = "0px";
     canvas.style.left = "0px";
@@ -132,6 +150,13 @@ export function rainbowCursor(options) {
   function loop() {
     updateParticles();
     requestAnimationFrame(loop);
+  }
+
+  function destroy() {
+    const cursor = document.getElementById('cursor-trail');
+    if (cursor) {
+      cursor.remove();
+    }
   }
 
   function Particle(x, y) {

--- a/src/snowflakeCursor.js
+++ b/src/snowflakeCursor.js
@@ -11,8 +11,26 @@ export function snowflakeCursor(options) {
 
   let canvImages = []
 
+  const prefersReducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)'
+  )
+
+  // Re-initialise or destroy the cursor when the prefers-reduced-motion setting changes
+  prefersReducedMotion.onchange = () => {
+    if (prefersReducedMotion.matches) {
+      destroy()
+    } else {
+      init()
+    }
+  }
+
   function init() {
-    canvas = document.createElement("canvas")
+    // Don't show the cursor trail if the user has prefers-reduced-motion enabled
+    if (prefersReducedMotion.matches) {
+      return false
+    }
+    canvas = document.createElement('canvas')
+    canvas.id = 'cursor-trail'
     context = canvas.getContext("2d")
 
     canvas.style.top = "0px"

--- a/src/springyEmojiCursor.js
+++ b/src/springyEmojiCursor.js
@@ -26,8 +26,26 @@ export function springyEmojiCursor(options) {
 
   let emojiAsImage
 
+  const prefersReducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)'
+  )
+
+  // Re-initialise or destroy the cursor when the prefers-reduced-motion setting changes
+  prefersReducedMotion.onchange = () => {
+    if (prefersReducedMotion.matches) {
+      destroy()
+    } else {
+      init()
+    }
+  }
+
   function init() {
-    canvas = document.createElement("canvas")
+    // Don't show the cursor trail if the user has prefers-reduced-motion enabled
+    if (prefersReducedMotion.matches) {
+      return false
+    }
+    canvas = document.createElement('canvas')
+    canvas.id = 'cursor-trail'
     context = canvas.getContext("2d")
     canvas.style.top = "0px"
     canvas.style.left = "0px"
@@ -201,6 +219,13 @@ export function springyEmojiCursor(options) {
     requestAnimationFrame(loop)
   }
 
+  function destroy() {
+    const cursor = document.getElementById('cursor-trail')
+    if (cursor) {
+      cursor.remove()
+    }
+  }
+  
   function vec(X, Y) {
     this.X = X
     this.Y = Y

--- a/src/trailingCursor.js
+++ b/src/trailingCursor.js
@@ -18,8 +18,26 @@ export function trailingCursor(options) {
   baseImage.src =
     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAATCAYAAACk9eypAAAAAXNSR0IArs4c6QAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAhGVYSWZNTQAqAAAACAAFARIAAwAAAAEAAQAAARoABQAAAAEAAABKARsABQAAAAEAAABSASgAAwAAAAEAAgAAh2kABAAAAAEAAABaAAAAAAAAAEgAAAABAAAASAAAAAEAA6ABAAMAAAABAAEAAKACAAQAAAABAAAADKADAAQAAAABAAAAEwAAAAAChpcNAAAACXBIWXMAAAsTAAALEwEAmpwYAAABWWlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50YXRpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgpMwidZAAABqElEQVQoFY3SPUvDQBgH8BREpRHExYiDgmLFl6WC+AYmWeyLg4i7buJX8DMpOujgyxGvUYeCgzhUQUSKKLUS0+ZyptXh8Z5Ti621ekPyJHl+uftfomhaf9Ei5JyxXKfynyEA6EYcLHpwyflT958GAQ7DTABNHd8EbtDbEH2BD5QEQmi2mM8P/Iq+A0SzszEg+3sPjDnDdVEtQKQbMUidHD3xVzf6A9UDEmEm+8h9KTqTVUjT+vB53aHrCbAPiceYq1dQI1Aqv4EhMll0jzv+Y0yiRgCnLRSYyDQHVoqUXe4uKL9l+L7GXC4vkMhE6eW/AOJs9k583ORDUyXMZ8F5SVHVVnllmPNKSFagAJ5DofaqGXw/gHBYg51dIldkmknY3tguv3jOtHR4+MqAzaraJXbEhqHhcQlwGSOi5pytVQHZLN5s0WNe8HPrLYlFsO20RPHkImxsbmHdLJFI76th7Z4SeuF53hTeFLvhRCJRCTKZKxgdnRDbW+iozFJbBMw14/ElwGYc0egMBMFzT21f5Rog33Z7dX02GBm7WV5ZfT5Nn5bE3zuCDe9UxdTpNvK+5AAAAABJRU5ErkJggg==";
 
+  const prefersReducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)'
+  );
+
+  // Re-initialise or destroy the cursor when the prefers-reduced-motion setting changes
+  prefersReducedMotion.onchange = () => {
+    if (prefersReducedMotion.matches) {
+      destroy();
+    } else {
+      init();
+    }
+  };
+
   function init() {
-    canvas = document.createElement("canvas");
+    // Don't show the cursor trail if the user has prefers-reduced-motion enabled
+    if (prefersReducedMotion.matches) {
+      return false;
+    }
+    canvas = document.createElement('canvas');
+    canvas.id = 'cursor-trail';
     context = canvas.getContext("2d");
     canvas.style.top = "0px";
     canvas.style.left = "0px";
@@ -102,6 +120,13 @@ export function trailingCursor(options) {
   function loop() {
     updateParticles();
     requestAnimationFrame(loop);
+  }
+
+  function destroy() {
+    const cursor = document.getElementById('cursor-trail');
+    if (cursor) {
+      cursor.remove();
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #26 

Extremely copy-pastey, but it seems like each cursor is its own encapsulated thing so it seemed like the thing to do.

* check `prefers-reduced-motion` when we init the cursor trail
* when the value of `prefers-reduced-motion` changes, either re-init or destroy the cursor trail
* add an `id` to the trail's canvas element, so that we can remove it from the DOM where necessary (this may help with #33?)