### PR TITLE
Added null check for options

### DIFF
--- a/src/rainbowCursor.js
+++ b/src/rainbowCursor.js
@@ -17,7 +17,7 @@ export function rainbowCursor(options) {
     "#0644B3",
     "#C22EDC",
   ];
-  const size = options.size || 3;
+  const size = options?.size || 3;
 
   let cursorsInitted = false;
 

--- a/src/trailingCursor.js
+++ b/src/trailingCursor.js
@@ -11,7 +11,7 @@ export function trailingCursor(options) {
   let particles = [];
   let canvas, context, animationFrame;
 
-  const totalParticles = options.particles || 15;
+  const totalParticles = options?.particles || 15;
   let cursorsInitted = false;
 
   let baseImage = new Image();


### PR DESCRIPTION
Added null checks to `options` in `rainbowCursor.js` and `trailingCursor.js`. These were failing when calling either of those functions without passing in an `options` variable. I tested all of the other cursor functions as well.