### PR TITLE
Reduce CPU usage for particle update no-ops

### DIFF
--- a/src/bubbleCursor.js
+++ b/src/bubbleCursor.js
@@ -106,6 +106,10 @@ export function bubbleCursor(options) {
   }
 
   function updateParticles() {
+    if (particles.length == 0) {
+      return;
+    }
+
     context.clearRect(0, 0, width, height);
 
     // Update
@@ -118,6 +122,10 @@ export function bubbleCursor(options) {
       if (particles[i].lifeSpan < 0) {
         particles.splice(i, 1);
       }
+    }
+
+    if (particles.length == 0) {
+      context.clearRect(0, 0, width, height);
     }
   }
 

--- a/src/emojiCursor.js
+++ b/src/emojiCursor.js
@@ -154,6 +154,10 @@ export function emojiCursor(options) {
   }
 
   function updateParticles() {
+    if (particles.length == 0) {
+      return;
+    }
+
     context.clearRect(0, 0, width, height);
 
     // Update
@@ -166,6 +170,10 @@ export function emojiCursor(options) {
       if (particles[i].lifeSpan < 0) {
         particles.splice(i, 1);
       }
+    }
+
+    if (particles.length == 0) {
+      context.clearRect(0, 0, width, height);
     }
   }
 

--- a/src/fairyDustCursor.js
+++ b/src/fairyDustCursor.js
@@ -155,6 +155,10 @@ export function fairyDustCursor(options) {
   }
 
   function updateParticles() {
+    if (particles.length == 0) {
+      return;
+    }
+
     context.clearRect(0, 0, width, height);
 
     // Update
@@ -167,6 +171,10 @@ export function fairyDustCursor(options) {
       if (particles[i].lifeSpan < 0) {
         particles.splice(i, 1);
       }
+    }
+
+    if (particles.length == 0) {
+      context.clearRect(0, 0, width, height);
     }
   }
 

--- a/src/ghostCursor.js
+++ b/src/ghostCursor.js
@@ -103,6 +103,10 @@ export function ghostCursor(options) {
   }
 
   function updateParticles() {
+    if (particles.length == 0) {
+      return;
+    }
+    
     context.clearRect(0, 0, width, height);
 
     // Update
@@ -115,6 +119,10 @@ export function ghostCursor(options) {
       if (particles[i].lifeSpan < 0) {
         particles.splice(i, 1);
       }
+    }
+
+    if (particles.length == 0) {
+      context.clearRect(0, 0, width, height);
     }
   }
 

--- a/src/snowflakeCursor.js
+++ b/src/snowflakeCursor.js
@@ -135,6 +135,10 @@ export function snowflakeCursor(options) {
   }
 
   function updateParticles() {
+    if (particles.length == 0) {
+      return;
+    }
+
     context.clearRect(0, 0, width, height);
 
     // Update
@@ -147,6 +151,10 @@ export function snowflakeCursor(options) {
       if (particles[i].lifeSpan < 0) {
         particles.splice(i, 1);
       }
+    }
+
+    if (particles.length == 0) {
+      context.clearRect(0, 0, width, height);
     }
   }
 


### PR DESCRIPTION
Hello and thank you for this very cool project!

I use the fairy dust cursor on my website, and I happened to notice that it was using up a non-negligible amount of CPU time even when the cursor was idle. Some quick experiments suggested that the `context.clearRect()` call in `updateParticles()` was the culprit.

This PR adds short-circuiting behaviour to `updateParticles()` so that we do less work when there are no particles to update. On my laptop[^1] CPU usage when idle goes from ~7% to 3%.

I applied the fix to every cursor where it looked like it might be relevant (because the number of particles can go to zero).

[^1]: Surface Pro 8, i7-1185G7 CPU, 120hz display, Windows 11, latest Edge. CPU usage measured using the Performance Monitor tab in dev tools, on my website with a slightly customized version of the fairy dust cursor. Not the most reproducible benchmark but hopefully it will do 😅