### PR TITLE
Add TypeScript declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cursor-effects",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cursor-effects",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "MIT",
       "devDependencies": {
         "rollup": "^2.77.0",

--- a/package.json
+++ b/package.json
@@ -5,15 +5,18 @@
   "version": "1.0.13",
   "main": "./dist/cjs.cjs",
   "module": "./dist/esm.js",
+  "types": "./types.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types.d.ts",
       "require": "./dist/cjs.cjs",
       "import": "./dist/esm.js"
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "types.d.ts"
   ],
   "publishConfig": {
     "access": "public",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,89 @@
+export type CursorEffectResult = {
+    destroy(): void;
+}
+
+type DefaultOptions = {
+    readonly element?: HTMLElement;
+}
+
+export type BubbleCursorOptions = {
+} & DefaultOptions;
+
+export type CharacterCursorOptions = {
+    readonly characters?: readonly string[];
+    readonly colors?: readonly string[];
+    readonly cursorOffset?: { readonly x: number; readonly y: number };
+    readonly font?: string;
+    readonly characterLifeSpanFunction?: () => number;
+    readonly initialCharacterVelocityFunction?: () => { readonly x: number; readonly y: number };
+    readonly characterScalingFunction?: () => number;
+    readonly characterNewRotationDegreesFunction?: (age: number, lifeSpan: number) => number;
+} & DefaultOptions;
+
+export type ClockCursorOptions = {
+    readonly dateColor?: string;
+    readonly faceColor?: string;
+    readonly secondsColor?: string;
+    readonly minutesColor?: string;
+    readonly hoursColor?: string;
+} & DefaultOptions;
+
+export type EmojiCursorOptions = {
+    readonly emoji?: readonly string[];
+} & DefaultOptions;
+
+export type FairyDustCursorOptions = {
+    colors?: readonly string[];
+} & DefaultOptions;
+
+export type FollowingDotCursorOptions = {
+    readonly color?: string;
+} & DefaultOptions;
+
+export type GhostCursorOptions = {
+    readonly randomDelay?: boolean;
+    readonly minDelay?: number;
+    readonly maxDelay?: number;
+    readonly image?: string;
+} & DefaultOptions;
+
+export type RainbowCursorOptions = {
+    length?: number;
+    colors?: readonly string[];
+    size?: number;
+} & DefaultOptions;
+
+export type SnowflakeCursorOptions = {
+} & DefaultOptions;
+
+export type SpringyEmojiCursorOptions = {
+    readonly emoji?: string;
+} & DefaultOptions;
+
+export type TextFlagOptions = {
+    readonly text?: string;
+    readonly color?: string;
+    readonly size?: number;
+    readonly font?: string;
+    readonly textSize?: number;
+    readonly gap?: number;
+} & DefaultOptions;
+
+export type TrailingCursorOptions = {
+    readonly particles?: number;
+    readonly rate?: number;
+    readonly baseImageSrc?: number;
+} & DefaultOptions;
+
+export function bubbleCursor(options?: BubbleCursorOptions): CursorEffectResult;
+export function characterCursor(options?: CharacterCursorOptions): CursorEffectResult;
+export function clockCursor(options?: ClockCursorOptions): CursorEffectResult;
+export function emojiCursor(options?: EmojiCursorOptions): CursorEffectResult;
+export function fairyDustCursor(options?: FairyDustCursorOptions): CursorEffectResult;
+export function followingDotCursor(options?: FollowingDotCursorOptions): CursorEffectResult;
+export function ghostCursor(options?: GhostCursorOptions): CursorEffectResult;
+export function rainbowCursor(options?: RainbowCursorOptions): CursorEffectResult;
+export function snowflakeCursor(options?: SnowflakeCursorOptions): CursorEffectResult;
+export function springyEmojiCursor(options?: SpringyEmojiCursorOptions): CursorEffectResult;
+export function textFlag(options?: TextFlagOptions): CursorEffectResult;
+export function trailingCursor(options?: TrailingCursorOptions): CursorEffectResult;


### PR DESCRIPTION
Adds TypeScript declarations.

Even if someone isn't a TypeScript user, I think these can be handy self-documentation of options for each function.

I'm open to any changes if you'd prefer a different format or style. Alternatively I can push these to the `@types` repo, but I do find many developers like seeing the types in the repo.


Use in an IDE:
![image](https://github.com/tholman/cursor-effects/assets/21208885/0a01ff37-8923-4cc6-85b7-441d753b1b74)

<img width="824" alt="image" src="https://github.com/tholman/cursor-effects/assets/21208885/71ce260c-e32a-42bc-b30e-a6834a307f61">

<img width="966" alt="image" src="https://github.com/tholman/cursor-effects/assets/21208885/c7db4619-e36d-4fb7-bccb-f929bad8b361">

