### PR TITLE
Add 'popstate' Event Listener for Cursor Destruction

### DIFF
--- a/src/bubbleCursor.js
+++ b/src/bubbleCursor.js
@@ -57,6 +57,7 @@ export function bubbleCursor(options) {
 
   // Bind events that are needed
   function bindEvents() {
+    window.addEventListener("popstate", destroy);
     element.addEventListener("mousemove", onMouseMove);
     element.addEventListener("touchmove", onTouchMove, { passive: true });
     element.addEventListener("touchstart", onTouchMove, { passive: true });

--- a/src/characterCursor.js
+++ b/src/characterCursor.js
@@ -137,6 +137,7 @@ export function characterCursor(options) {
 
   // Bind events that are needed
   function bindEvents() {
+    window.addEventListener("popstate", destroy);
     element.addEventListener("mousemove", onMouseMove);
     element.addEventListener("touchmove", onTouchMove, { passive: true });
     element.addEventListener("touchstart", onTouchMove, { passive: true });

--- a/src/clockCursor.js
+++ b/src/clockCursor.js
@@ -208,6 +208,7 @@ export function clockCursor(options) {
 
   // Bind events that are needed
   function bindEvents() {
+    window.addEventListener("popstate", destroy);
     element.addEventListener("mousemove", onMouseMove);
     element.addEventListener("touchmove", onTouchMove, { passive: true });
     element.addEventListener("touchstart", onTouchMove, { passive: true });

--- a/src/emojiCursor.js
+++ b/src/emojiCursor.js
@@ -83,6 +83,7 @@ export function emojiCursor(options) {
 
   // Bind events that are needed
   function bindEvents() {
+    window.addEventListener("popstate", destroy);
     element.addEventListener("mousemove", onMouseMove, { passive: true });
     element.addEventListener("touchmove", onTouchMove, { passive: true });
     element.addEventListener("touchstart", onTouchMove, { passive: true });

--- a/src/fairyDustCursor.js
+++ b/src/fairyDustCursor.js
@@ -90,6 +90,7 @@ export function fairyDustCursor(options) {
 
   // Bind events that are needed
   function bindEvents() {
+    window.addEventListener("popstate", destroy);
     element.addEventListener("mousemove", onMouseMove);
     element.addEventListener("touchmove", onTouchMove, { passive: true });
     element.addEventListener("touchstart", onTouchMove, { passive: true });

--- a/src/followingDotCursor.js
+++ b/src/followingDotCursor.js
@@ -55,6 +55,7 @@ export function followingDotCursor(options) {
 
   // Bind events that are needed
   function bindEvents() {
+    window.addEventListener("popstate", destroy);
     element.addEventListener("mousemove", onMouseMove);
     window.addEventListener("resize", onWindowResize);
   }

--- a/src/ghostCursor.js
+++ b/src/ghostCursor.js
@@ -66,6 +66,7 @@ export function ghostCursor(options) {
 
   // Bind events that are needed
   function bindEvents() {
+    window.addEventListener("popstate", destroy);
     element.addEventListener("mousemove", onMouseMove);
     element.addEventListener("touchmove", onTouchMove, { passive: true });
     element.addEventListener("touchstart", onTouchMove, { passive: true });

--- a/src/rainbowCursor.js
+++ b/src/rainbowCursor.js
@@ -67,6 +67,7 @@ export function rainbowCursor(options) {
 
   // Bind events that are needed
   function bindEvents() {
+    window.addEventListener("popstate", destroy);
     element.addEventListener("mousemove", onMouseMove);
     window.addEventListener("resize", onWindowResize);
   }

--- a/src/snowflakeCursor.js
+++ b/src/snowflakeCursor.js
@@ -82,6 +82,7 @@ export function snowflakeCursor(options) {
 
   // Bind events that are needed
   function bindEvents() {
+    window.addEventListener("popstate", destroy);
     element.addEventListener("mousemove", onMouseMove);
     element.addEventListener("touchmove", onTouchMove, { passive: true });
     element.addEventListener("touchstart", onTouchMove, { passive: true });

--- a/src/springyEmojiCursor.js
+++ b/src/springyEmojiCursor.js
@@ -100,6 +100,7 @@ export function springyEmojiCursor(options) {
 
   // Bind events that are needed
   function bindEvents() {
+    window.addEventListener("popstate", destroy);
     element.addEventListener("mousemove", onMouseMove);
     element.addEventListener("touchmove", onTouchMove, { passive: true });
     element.addEventListener("touchstart", onTouchMove, { passive: true });

--- a/src/textFlag.js
+++ b/src/textFlag.js
@@ -82,6 +82,7 @@ export function textFlag(options) {
 
   // Bind events that are needed
   function bindEvents() {
+    window.addEventListener("popstate", destroy);
     element.addEventListener("mousemove", onMouseMove);
     window.addEventListener("resize", onWindowResize);
   }

--- a/src/trailingCursor.js
+++ b/src/trailingCursor.js
@@ -65,6 +65,7 @@ export function trailingCursor(options) {
 
   // Bind events that are needed
   function bindEvents() {
+    window.addEventListener("popstate", destroy);
     element.addEventListener("mousemove", onMouseMove);
     window.addEventListener("resize", onWindowResize);
   }


### PR DESCRIPTION
Added a 'popstate' event listener to trigger cursor destruction on window navigation. This fix addresses issues encountered in single-page applications (React).