### PR TITLE
fix (types): allow baseImageSrc property to use string

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -74,7 +74,7 @@ export type TextFlagOptions = {
 export type TrailingCursorOptions = {
     readonly particles?: number;
     readonly rate?: number;
-    readonly baseImageSrc?: number;
+    readonly baseImageSrc?: number | string;
 } & DefaultOptions;
 
 export function bubbleCursor(options?: BubbleCursorOptions): CursorEffectResult;


### PR DESCRIPTION
Hey, tholman! Used a `number | string` union to prevent breaking change for previous versions.