### PR TITLE
Add delay parameter to emoji frequency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -114,10 +114,11 @@ new cursoreffects.fairyDustCursor({
 
 ### emojiCursor
 
-You can change the emoji in `emojiCursor`'s emoji with the `emoji` option (a list of emoji)
+You can change the emoji in `emojiCursor`'s emoji with the `emoji` option (a list of emoji),
+and delay between emoji with the `delay` option (defaults to `16`)
 
 ```js
-new cursoreffects.emojiCursor({ emoji: ["🔥", "🐬", "🦆"] });
+new cursoreffects.emojiCursor({ emoji: ["🔥", "🐬", "🦆"], delay: 25 });
 ```
 
 ### textFlag

--- a/src/emojiCursor.js
+++ b/src/emojiCursor.js
@@ -1,5 +1,6 @@
 export function emojiCursor(options) {
   const possibleEmoji = (options && options.emoji) || ["😀", "😂", "😆", "😊"];
+  const delay = (options && options.delay) || 16;
   let hasWrapperEl = options && options.element;
   let element = hasWrapperEl || document.body;
 
@@ -116,7 +117,7 @@ export function emojiCursor(options) {
 
   function onMouseMove(e) {
     // Dont run too fast
-    if (e.timeStamp - lastTimestamp < 16) {
+    if (e.timeStamp - lastTimestamp < delay) {
       return;
     }
 
@@ -189,7 +190,7 @@ export function emojiCursor(options) {
     element.removeEventListener("touchmove", onTouchMove);
     element.removeEventListener("touchstart", onTouchMove);
     window.addEventListener("resize", onWindowResize);
-  };
+  }
 
   /**
    * Particles
@@ -228,6 +229,6 @@ export function emojiCursor(options) {
   init();
 
   return {
-    destroy: destroy
-  }
+    destroy: destroy,
+  };
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -32,6 +32,7 @@ export type ClockCursorOptions = {
 
 export type EmojiCursorOptions = {
     readonly emoji?: readonly string[];
+    readonly delay?: number;
 } & DefaultOptions;
 
 export type FairyDustCursorOptions = {


### PR DESCRIPTION
This adds an optional `delay` parameter to the `emojiCursor` so you can easily make emoji appear faster or slower.

I forked this for an easter egg on [my personal site](https://github.com/aryaburke/my-site) and wanted to also add it here. You can test it out on my site by hitting the Konami code (or just the up arrow while it's still in debug mode)