### PR TITLE
Extended FairyDust Options – Symbol Customization

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,11 +115,12 @@ new cursoreffects.bubbleCursor({
 
 ### fairyDustCursor
 
-You can change the emoji in `fairyDustCursor`'s colors with the `colors` option (an array of colors)
+You can customize the `fairyDustCursor` by using the `fairySymbol` option to change the emoji, and the `colors` option (an array) to define its trail colors.
 
 ```js
 new cursoreffects.fairyDustCursor({
   colors: ["#ff0000", "#00ff00", "#0000ff"],
+  fairySymbol: "★",
 });
 ```
 

--- a/src/fairyDustCursor.js
+++ b/src/fairyDustCursor.js
@@ -15,7 +15,7 @@ export function fairyDustCursor(options) {
   const canvImages = [];
   let canvas, context, animationFrame;
 
-  const char = "*";
+  const char = options.fairySymbol || "*";
 
   const prefersReducedMotion = window.matchMedia(
     "(prefers-reduced-motion: reduce)"


### PR DESCRIPTION
Users can now change the fairy symbol using the `fairySymbo`l parameter.
The documentation has also been updated to reflect this enhancement.