### PR TITLE
Add zIndex option to cursor styles for better layering control

### DIFF
--- a/src/bubbleCursor.js
+++ b/src/bubbleCursor.js
@@ -40,6 +40,7 @@ export function bubbleCursor(options) {
     canvas.style.top = "0px";
     canvas.style.left = "0px";
     canvas.style.pointerEvents = "none";
+    canvas.style.zIndex = options.zIndex || "9999999999";
 
     if (hasWrapperEl) {
       canvas.style.position = "absolute";

--- a/src/characterCursor.js
+++ b/src/characterCursor.js
@@ -91,6 +91,7 @@ export function characterCursor(options) {
     canvas.style.top = "0px";
     canvas.style.left = "0px";
     canvas.style.pointerEvents = "none";
+    canvas.style.zIndex = options.zIndex || "9999999999";
 
     if (hasWrapperEl) {
       canvas.style.position = "absolute";

--- a/src/clockCursor.js
+++ b/src/clockCursor.js
@@ -137,6 +137,7 @@ export function clockCursor(options) {
     canvas.style.top = "0px";
     canvas.style.left = "0px";
     canvas.style.pointerEvents = "none";
+    canvas.style.zIndex = options.zIndex || "9999999999";
 
     if (hasWrapperEl) {
       canvas.style.position = "absolute";

--- a/src/emojiCursor.js
+++ b/src/emojiCursor.js
@@ -41,6 +41,7 @@ export function emojiCursor(options) {
     canvas.style.top = "0px";
     canvas.style.left = "0px";
     canvas.style.pointerEvents = "none";
+    canvas.style.zIndex = options.zIndex || "9999999999";
 
     if (hasWrapperEl) {
       canvas.style.position = "absolute";

--- a/src/fairyDustCursor.js
+++ b/src/fairyDustCursor.js
@@ -44,6 +44,7 @@ export function fairyDustCursor(options) {
     canvas.style.top = "0px";
     canvas.style.left = "0px";
     canvas.style.pointerEvents = "none";
+    canvas.style.zIndex = options.zIndex || "9999999999";
 
     if (hasWrapperEl) {
       canvas.style.position = "absolute";

--- a/src/followingDotCursor.js
+++ b/src/followingDotCursor.js
@@ -36,6 +36,7 @@ export function followingDotCursor(options) {
     canvas.style.top = "0px";
     canvas.style.left = "0px";
     canvas.style.pointerEvents = "none";
+    canvas.style.zIndex = options.zIndex || "9999999999";
 
     if (hasWrapperEl) {
       canvas.style.position = "absolute";

--- a/src/ghostCursor.js
+++ b/src/ghostCursor.js
@@ -48,6 +48,7 @@ export function ghostCursor(options) {
     canvas.style.top = "0px";
     canvas.style.left = "0px";
     canvas.style.pointerEvents = "none";
+    canvas.style.zIndex = options.zIndex || "9999999999";
 
     if (hasWrapperEl) {
       canvas.style.position = "absolute";

--- a/src/rainbowCursor.js
+++ b/src/rainbowCursor.js
@@ -48,6 +48,7 @@ export function rainbowCursor(options) {
     canvas.style.top = "0px";
     canvas.style.left = "0px";
     canvas.style.pointerEvents = "none";
+    canvas.style.zIndex = options.zIndex || "9999999999";
 
     if (hasWrapperEl) {
       canvas.style.position = "absolute";

--- a/src/snowflakeCursor.js
+++ b/src/snowflakeCursor.js
@@ -39,6 +39,7 @@ export function snowflakeCursor(options) {
     canvas.style.top = "0px";
     canvas.style.left = "0px";
     canvas.style.pointerEvents = "none";
+    canvas.style.zIndex = options.zIndex || "9999999999";
 
     if (hasWrapperEl) {
       canvas.style.position = "absolute";

--- a/src/springyEmojiCursor.js
+++ b/src/springyEmojiCursor.js
@@ -53,6 +53,7 @@ export function springyEmojiCursor(options) {
     canvas.style.top = "0px";
     canvas.style.left = "0px";
     canvas.style.pointerEvents = "none";
+    canvas.style.zIndex = options.zindex || "9999999999";
 
     if (hasWrapperEl) {
       canvas.style.position = "absolute";

--- a/src/textFlag.js
+++ b/src/textFlag.js
@@ -65,6 +65,7 @@ export function textFlag(options) {
     canvas.style.top = "0px";
     canvas.style.left = "0px";
     canvas.style.pointerEvents = "none";
+    canvas.style.zIndex = options.zIndex || "9999999999";
 
     if (hasWrapperEl) {
       canvas.style.position = "absolute";

--- a/src/trailingCursor.js
+++ b/src/trailingCursor.js
@@ -46,6 +46,7 @@ export function trailingCursor(options) {
     canvas.style.top = "0px";
     canvas.style.left = "0px";
     canvas.style.pointerEvents = "none";
+    canvas.style.zIndex = options.zIndex || "9999999999";
 
     if (hasWrapperEl) {
       canvas.style.position = "absolute";


### PR DESCRIPTION
If any element inside an effect-enabled section has a set z-index, the trail may appear behind it.
This solution resolves that issue and allows users to control the layering of page elements by adjusting their z-index value. 